### PR TITLE
send URL in 'convert' requests

### DIFF
--- a/chrome-extension/src/content-script/index.js
+++ b/chrome-extension/src/content-script/index.js
@@ -20,7 +20,10 @@ function main() {
     const kubeLines = getLinesFromRows(kubeRows);
 
     const kokiRows = new Promise((resolve, reject) => {
-        sendFileContents(kubeLines, (content) => {
+        sendFileContents({
+            url: window.location.href,
+            lines: kubeLines
+        }, (content) => {
             resolve(buildRowsForContent(content));
         }, reject);
     });
@@ -107,10 +110,10 @@ function updateFileWithInfo(fileInfo, fileData) {
     $('#pretty-yaml-data').text(fileData);
 }
 
-function sendFileContents(lines, onSuccess, onError) {
+function sendFileContents(request, onSuccess, onError) {
     const port = chrome.runtime.connect();
     port.postMessage({
-        fileLines: lines
+        linesRequest: request
     });
     port.onMessage.addListener(function(msg) {
         if (msg.error) {

--- a/server/logging/logging.go
+++ b/server/logging/logging.go
@@ -12,7 +12,11 @@ type Session struct {
 }
 
 type Convert struct {
+	URL         string `json:"url,omitempty"`
 	Unconverted string `json:"unconverted,omitempty"`
+
+	// error parsing the Convert request body.
+	RequestError string `json:"request_error,omitempty"`
 }
 
 type Login struct {
@@ -59,9 +63,11 @@ func MkSession(sessionValues map[interface{}]interface{}) *Session {
 	}
 }
 
-func MkConvert(unconverted string) *Convert {
+func MkConvert(url, unconverted, err string) *Convert {
 	return &Convert{
-		Unconverted: unconverted,
+		URL:          url,
+		Unconverted:  unconverted,
+		RequestError: err,
 	}
 }
 


### PR DESCRIPTION
@wlan0 #1

Logs are completely JSON (using logrus), so they'll be on one line for Cloudwatch.
Chrome extension now sends URL along with YAML. Old Chrome extension still works with new server, in case it takes a while for the extension to be updated.